### PR TITLE
Add typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+import * as Future from 'fluture'
+
+declare function retry(time: (a: number) => number): (max: number) => <A, B>(task: Future.FutureInstance<A, B>) => Future.FutureInstance<A[], B>;
+declare function exponentially(t: number): (n: number) => number;
+declare function linearly(t: number): (n: number) => number;
+declare function statically(t: number): (_: any) => number;
+declare function linearSeconds(n: number): number;
+declare function retryLinearly<A, B>(task: Future.FutureInstance<A, B>): Future.FutureInstance<A, B>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as Future from 'fluture'
 
-declare function retry(time: (a: number) => number): (max: number) => <A, B>(task: Future.FutureInstance<A, B>) => Future.FutureInstance<A[], B>;
+declare function retry(time: (tries: number) => number): (max: number) => <A, B>(task: Future.FutureInstance<A, B>) => Future.FutureInstance<A[], B>;
 declare function exponentially(t: number): (n: number) => number;
 declare function linearly(t: number): (n: number) => number;
 declare function statically(t: number): (_: any) => number;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "Toolset for retrying potentially failing computations",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "doctest": "sanctuary-doctest",
     "lint": "sanctuary-lint",
@@ -19,6 +20,7 @@
   ],
   "files": [
     "/index.js",
+    "/index.d.ts",
     "/LICENSE",
     "/package.json",
     "/README.md"


### PR DESCRIPTION
Hello, nifty project! Thanks for your work on fluture-retry and fluture as a whole. 

This PR adds typescript typings, which I have tested by publishing to a local npm-registry under a scoped namespace and installed and successfully used from a typescript package.

I am unable to get `npm test` to pass, the `lint` run-script fails with message

```
node_modules/.bin/sanctuary-generate-readme: line 33: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
events.js:187
      throw er; // Unhandled 'error' event
```

however on my machine this also occurs on the unchanged master branch and I do not think this breakage was introduced by my changes. 

I'm more than happy to address any feedback.

Please note I have not bumped any npm versions so that will have to be done manually before publishing these updates to npm.

Thanks again for publishing fluture-retry!